### PR TITLE
Removing the NotSupportedException in order to reduce the amount of errors in the log file regarding extensions this package is not supporting.

### DIFF
--- a/src/UmbracoExamine.PDF/PDFIndexer.cs
+++ b/src/UmbracoExamine.PDF/PDFIndexer.cs
@@ -1,21 +1,14 @@
-﻿using System;
+﻿using Examine;
+using Lucene.Net.Analysis;
+using Newtonsoft.Json.Linq;
+using System;
 using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.IO;
 using System.Linq;
-using System.Security;
-using System.Text.RegularExpressions;
 using System.Xml.Linq;
-using Examine;
-using iTextSharp.text.exceptions;
-using iTextSharp.text.pdf;
-using System.Text;
-using Lucene.Net.Analysis;
-using UmbracoExamine.DataServices;
-using iTextSharp.text.pdf.parser;
 using Umbraco.Core;
-using Newtonsoft.Json.Linq;
-using Umbraco.Core.Logging;
+using UmbracoExamine.DataServices;
 
 namespace UmbracoExamine.PDF
 {


### PR DESCRIPTION
I included this to reduce the number of errors (RED) we're getting in the log-file, now these are being logged as info.