### PR TITLE
Only index published PDF documents (i.e. documents not in the recycle bin).

### DIFF
--- a/src/UmbracoExamine.PDF/ConfigurePdfIndexOptions.cs
+++ b/src/UmbracoExamine.PDF/ConfigurePdfIndexOptions.cs
@@ -26,7 +26,7 @@ namespace UmbracoExamine.PDF
             if (name.Equals(PdfIndexConstants.PdfIndexName))
             {
                 options.Analyzer = new StandardAnalyzer(LuceneVersion.LUCENE_48);
-                options.Validator = new PdfValueSetValidator(null);
+                options.Validator = new PdfValueSetValidator(true, null);
                 options.FieldDefinitions = new FieldDefinitionCollection(
                     new FieldDefinition(PdfIndexConstants.PdfContentFieldName,FieldDefinitionTypes.FullText));
 

--- a/src/UmbracoExamine.PDF/ConfigurePdfIndexOptions.cs
+++ b/src/UmbracoExamine.PDF/ConfigurePdfIndexOptions.cs
@@ -26,7 +26,7 @@ namespace UmbracoExamine.PDF
             if (name.Equals(PdfIndexConstants.PdfIndexName))
             {
                 options.Analyzer = new StandardAnalyzer(LuceneVersion.LUCENE_48);
-                options.Validator = new PdfValueSetValidator(true, null);
+                options.Validator = new PdfValueSetValidator(null, true);
                 options.FieldDefinitions = new FieldDefinitionCollection(
                     new FieldDefinition(PdfIndexConstants.PdfContentFieldName,FieldDefinitionTypes.FullText));
 

--- a/src/UmbracoExamine.PDF/PdfLuceneIndex.cs
+++ b/src/UmbracoExamine.PDF/PdfLuceneIndex.cs
@@ -1,5 +1,7 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
+using Examine;
 using Examine.Lucene;
 using Examine.Lucene.Providers;
 using Microsoft.Extensions.Logging;
@@ -31,6 +33,62 @@ namespace UmbracoExamine.PDF
 
         #endregion
 
+        /// <summary>
+        ///     Special check for invalid paths
+        /// </summary>
+        /// <param name="values"></param>
+        /// <param name="onComplete"></param>
+        protected override void PerformIndexItems(IEnumerable<ValueSet> values, Action<IndexOperationEventArgs> onComplete)
+        {
+            // We don't want to re-enumerate this list, but we need to split it into 2x enumerables: invalid and valid items.
+            // The Invalid items will be deleted, these are items that have invalid paths (i.e. moved to the recycle bin, etc...)
+            // Then we'll index the Value group all together.
+            var invalidOrValid = values.GroupBy(v =>
+            {
+                if (!v.Values.TryGetValue("path", out IReadOnlyList<object> paths) || paths.Count <= 0 || paths[0] == null)
+                {
+                    return ValueSetValidationStatus.Failed;
+                }
 
+                ValueSetValidationResult validationResult = ValueSetValidator.Validate(v);
+
+                return validationResult.Status;
+            }).ToArray();
+
+            var hasDeletes = false;
+            var hasUpdates = false;
+
+            // ordering by descending so that Filtered/Failed processes first
+            foreach (IGrouping<ValueSetValidationStatus, ValueSet> group in invalidOrValid.OrderByDescending(x => x.Key))
+            {
+                switch (group.Key)
+                {
+                    case ValueSetValidationStatus.Valid:
+                        hasUpdates = true;
+
+                        //these are the valid ones, so just index them all at once
+                        base.PerformIndexItems(group.ToArray(), onComplete);
+                        break;
+                    case ValueSetValidationStatus.Failed:
+                        // don't index anything that is invalid
+                        break;
+                    case ValueSetValidationStatus.Filtered:
+                        hasDeletes = true;
+
+                        // these are the invalid/filtered items so we'll delete them
+                        // since the path is not valid we need to delete this item in
+                        // case it exists in the index already and has now
+                        // been moved to an invalid parent.
+                        base.PerformDeleteFromIndex(group.Select(x => x.Id), null);
+                        break;
+                }
+            }
+
+            if ((hasDeletes && !hasUpdates) || (!hasDeletes && !hasUpdates))
+            {
+                //we need to manually call the completed method
+                onComplete(new IndexOperationEventArgs(this, 0));
+            }
+        }
     }
 }

--- a/src/UmbracoExamine.PDF/PdfLuceneIndex.cs
+++ b/src/UmbracoExamine.PDF/PdfLuceneIndex.cs
@@ -55,7 +55,6 @@ namespace UmbracoExamine.PDF
                 return validationResult.Status;
             }).ToArray();
 
-            var hasDeletes = false;
             var hasUpdates = false;
 
             // ordering by descending so that Filtered/Failed processes first
@@ -73,8 +72,6 @@ namespace UmbracoExamine.PDF
                         // don't index anything that is invalid
                         break;
                     case ValueSetValidationStatus.Filtered:
-                        hasDeletes = true;
-
                         // these are the invalid/filtered items so we'll delete them
                         // since the path is not valid we need to delete this item in
                         // case it exists in the index already and has now
@@ -84,7 +81,7 @@ namespace UmbracoExamine.PDF
                 }
             }
 
-            if ((hasDeletes && !hasUpdates) || (!hasDeletes && !hasUpdates))
+            if (!hasUpdates)
             {
                 //we need to manually call the completed method
                 onComplete(new IndexOperationEventArgs(this, 0));

--- a/src/UmbracoExamine.PDF/PdfValueSetValidator.cs
+++ b/src/UmbracoExamine.PDF/PdfValueSetValidator.cs
@@ -21,9 +21,8 @@ namespace UmbracoExamine.PDF
             int? parentId,
             IEnumerable<string> includeItemTypes = null,
             IEnumerable<string> excludeItemTypes = null)
-            : base(includeItemTypes, excludeItemTypes, null, null)
+            : this(parentId, false, includeItemTypes, excludeItemTypes)
         {
-            ParentId = parentId;
         }
 
         public PdfValueSetValidator(
@@ -37,6 +36,7 @@ namespace UmbracoExamine.PDF
             PublishedValuesOnly = publishedValuesOnly;
         }
 
+        // TODO (next major): make this method private
         public bool ValidatePath(string path)
         {
             //check if this document is a descendent of the parent
@@ -51,7 +51,7 @@ namespace UmbracoExamine.PDF
             return true;
         }
 
-        public bool ValidateRecycleBin(string path, string category)
+        private bool ValidateRecycleBin(string path, string category)
         {
             var recycleBinId = category == IndexTypes.Content
                 ? Constants.System.RecycleBinContentString

--- a/src/UmbracoExamine.PDF/PdfValueSetValidator.cs
+++ b/src/UmbracoExamine.PDF/PdfValueSetValidator.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using Examine;
 using Umbraco.Cms.Core;
@@ -9,19 +10,31 @@ namespace UmbracoExamine.PDF
 {
     public class PdfValueSetValidator : ValueSetValidator
     {
-        public bool PublishedValuesOnly { get; }
-
         public int? ParentId { get; }
+
+        public bool PublishedValuesOnly { get; }
 
         private const string PathKey = "path";
 
-        public PdfValueSetValidator(bool publishedValuesOnly, 
+        [Obsolete("Please use the constructor taking all parameters. This constructor will be removed in a future version.")]
+        public PdfValueSetValidator(
             int? parentId,
-            IEnumerable<string> includeItemTypes = null, IEnumerable<string> excludeItemTypes = null)
+            IEnumerable<string> includeItemTypes = null,
+            IEnumerable<string> excludeItemTypes = null)
             : base(includeItemTypes, excludeItemTypes, null, null)
         {
-            PublishedValuesOnly = publishedValuesOnly;
             ParentId = parentId;
+        }
+
+        public PdfValueSetValidator(
+            int? parentId,
+            bool publishedValuesOnly,
+            IEnumerable<string> includeItemTypes = null,
+            IEnumerable<string> excludeItemTypes = null)
+            : base(includeItemTypes, excludeItemTypes, null, null)
+        {
+            ParentId = parentId;
+            PublishedValuesOnly = publishedValuesOnly;
         }
 
         public bool ValidatePath(string path)


### PR DESCRIPTION
**Problem**

If a PDF document is deleted and in the recycle bin, it is correctly removed from the index but if the index is rebuilt it is included again.  The index is indexing documents regardless of whether they are in the recycle bin or not.  I have made some changes to ignore PDF documents in the recycle bin using similar code to the Umbraco built-in ContentValueSetValidator and the UmbracoContentIndex.

**Steps to Reproduce**

1. Add a PDF document to the media library
2. Use the Examine tab to search the contents of the PDF document - it should return a matching result
3. Delete the document so it goes into the recycle bin
4. Use the Examine tab to search the contents of the PDF document - it should not return a matching result
5. Rebuild the PDF index
6. Use the Examine tab to search the contents of the PDF document - it should not return a matching result but it does

I have made an assumption that the PDF index is likely to be be used externally so PDF documents in the recycle bin should not be included.  If you want the reverse by default and think this should be actived by a config setting please let me know.