### PR TITLE
Extract hyperlinks found in PDF and add them to a new field

### DIFF
--- a/src/UmbracoExamine.PDF/IPdfTextExtractor.cs
+++ b/src/UmbracoExamine.PDF/IPdfTextExtractor.cs
@@ -5,5 +5,6 @@ namespace UmbracoExamine.PDF
     public interface IPdfTextExtractor
     {
         string GetTextFromPdf(Stream pdfFileStream);
+        string GetLinkFromPdf(Stream pdfFileStream);
     }
 }

--- a/src/UmbracoExamine.PDF/PdfIndexConstants.cs
+++ b/src/UmbracoExamine.PDF/PdfIndexConstants.cs
@@ -4,6 +4,7 @@
     {
         public const string PdfIndexName = "PDFIndex";
         public const string PdfContentFieldName = "fileTextContent";
+        public const string PdfLinksFieldName = "fileLinks";
         public const string UmbracoMediaExtensionPropertyAlias = "umbracoExtension";
         public const string PdfFileExtension = "pdf";
         public const string PdfCategory = "pdf";

--- a/src/UmbracoExamine.PDF/PdfIndexValueSetBuilder.cs
+++ b/src/UmbracoExamine.PDF/PdfIndexValueSetBuilder.cs
@@ -31,9 +31,11 @@ namespace UmbracoExamine.PDF
                 if (string.IsNullOrWhiteSpace(umbracoFile)) continue;
 
                 string fileTextContent;
+                string fileLinks;
                 try
                 {
                     fileTextContent = ExtractTextFromFile(umbracoFile);
+                    fileLinks = ExtractLinkFromFile(umbracoFile);
                 }
                 catch (Exception ex)
                 {
@@ -45,7 +47,8 @@ namespace UmbracoExamine.PDF
                     ["nodeName"] = item.Name,
                     ["id"] = item.Id,
                     ["path"] =  item.Path,
-                    [PdfIndexConstants.PdfContentFieldName] = fileTextContent
+                    [PdfIndexConstants.PdfContentFieldName] = fileTextContent,
+                    [PdfIndexConstants.PdfLinksFieldName] = fileLinks
                 };
 
                 var valueSet = new ValueSet(item.Id.ToString(), PdfIndexConstants.PdfCategory, item.ContentType.Alias, indexValues);
@@ -59,6 +62,19 @@ namespace UmbracoExamine.PDF
             try
             {
                 return _pdfTextService.ExtractText(filePath);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Could not extract text from PDF {PdfFilePath}", filePath);
+                return string.Empty;
+            }
+        }
+
+        private string ExtractLinkFromFile(string filePath)
+        {
+            try
+            {
+                return _pdfTextService.ExtractLink(filePath);
             }
             catch (Exception ex)
             {

--- a/src/UmbracoExamine.PDF/PdfPigTextExtractor.cs
+++ b/src/UmbracoExamine.PDF/PdfPigTextExtractor.cs
@@ -25,5 +25,23 @@ namespace UmbracoExamine.PDF
                 return result.ToString();
             }
         }
+
+        public string GetLinkFromPdf(Stream pdfFileStream)
+        {
+            using (PdfDocument document = PdfDocument.Open(pdfFileStream))
+            {
+                var result = new StringBuilder();
+
+                foreach (Page page in document.GetPages())
+                {
+                    // page.Text in some test cases runs words together where page.GetWords keeps them seperated
+                    // so we use page.GetWords() instead of the simpler page.Text
+                    IEnumerable<Hyperlink> links = page.GetHyperlinks();
+                    result.Append(string.Join(" ", links));
+                    result.AppendLine();
+                }
+                return result.ToString();
+            }
+        }
     }
 }

--- a/src/UmbracoExamine.PDF/PdfTextService.cs
+++ b/src/UmbracoExamine.PDF/PdfTextService.cs
@@ -48,6 +48,27 @@ namespace UmbracoExamine.PDF
         }
 
         /// <summary>
+        /// Extract links from a PDF file at the given path
+        /// </summary>
+        /// <param name="filePath"></param>
+        /// <returns></returns>
+        public string ExtractLink(string filePath)
+        {
+            using (var fs = _mediaFileSystem.FileSystem.OpenFile(filePath))
+            {
+                if (fs != null)
+                {
+                    return ExceptChars(_pdfTextExtractor.GetLinkFromPdf(fs), UnsupportedRange.Value, ReplaceWithSpace);
+                }
+                else
+                {
+                    _logger.LogError(new Exception($"Unable to open PDF file {filePath}"), "Unable to Open PDF file");
+                    return null;
+                }
+            }
+        }
+
+        /// <summary>
         /// Stores the unsupported range of character
         /// </summary>
         /// <remarks>


### PR DESCRIPTION
**Problem**

Looks like hyperlinks aren't indexed at the moment i.e. if you have "click [here](https://github.com/umbraco/UmbracoExamine.PDF)", only the text "click here" is indexed - there's no way to search for the actual URL.

**Solution**

In this PR, I've tried to extract (using PdfPig's Page.GetHyperlinks()) and save the links in a new field, thought this might be useful.